### PR TITLE
Fixed failing tests in OBS build

### DIFF
--- a/test/dialogs/registration_test.rb
+++ b/test/dialogs/registration_test.rb
@@ -3,6 +3,10 @@ require "cwm/rspec"
 require "migration_sle/dialogs/registration"
 
 describe MigrationSle::Dialogs::Registration do
+  before do
+    allow(Yast::OSRelease).to receive(:ReleaseInformation).and_return("openSUSE Leap 15.4")
+  end
+
   include_examples "CWM::Dialog"
 
   describe "#help" do

--- a/test/main_workflow_test.rb
+++ b/test/main_workflow_test.rb
@@ -17,6 +17,10 @@ describe MigrationSle::MainWorkflow do
     }
   end
 
+  before do
+    allow(Yast::OSRelease).to receive(:ReleaseInformation).and_return("openSUSE Leap 15.4")
+  end
+
   describe "#run" do
     before do
       allow(Yast::Wizard).to receive(:CreateDialog)

--- a/test/repos_workflow_test.rb
+++ b/test/repos_workflow_test.rb
@@ -6,6 +6,11 @@ describe MigrationSle::ReposWorkflow do
 
   describe "#select_migration_products" do
     before do
+      # avoid SLP network scan
+      # note: the scan is done in the constructor, make sure it is mocked
+      # *before* calling "subject"
+      allow(Registration::UrlHelpers).to receive(:registration_url)
+
       allow(Yast::OSRelease).to receive(:ReleaseVersion).and_return("15.4")
       allow(subject).to receive(:migrations).and_return(migrations)
     end


### PR DESCRIPTION
## Problem

- Jenkins failed with `Release file /etc/os-release not found` error
- https://ci.opensuse.org/view/Yast/job/yast-yast-migration-sle-master/1/console

## Solution

- Fixed unit tests
- Additionally added mock for obtaining the registration URL which runs a SLP server scan, that's not nice to run for real in the tests

## Notes

- No version bump as the package was not released yet (failed in Jenkins)
