### PR TITLE
Reword the help text in the registration dialog (JSC#SLE-24216)

### DIFF
--- a/package/yast2-migration-sle.changes
+++ b/package/yast2-migration-sle.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 14 12:53:27 UTC 2022 - Ladislav Slezák <lslezak@suse.com>
+
+- Improved help texts (jsc#SLE-24216) (by Christoph Wickert)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-migration-sle.spec
+++ b/package/yast2-migration-sle.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration-sle
-Version:        4.5.2
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Online migration
 Group:          System/YaST

--- a/package/yast2-migration-sle.spec
+++ b/package/yast2-migration-sle.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-migration-sle
-Version:        4.5.0
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Online migration
 Group:          System/YaST

--- a/src/lib/migration_sle/dialogs/registration.rb
+++ b/src/lib/migration_sle/dialogs/registration.rb
@@ -110,8 +110,11 @@ module MigrationSle
       # rubocop:disable Layout/HeredocIndentation, Metrics/MethodLength
       def help
         # TRANSLATORS: help text for the main dialog of the online search feature,
+        # the "%{from_system}" is replaced by the current system name, e.g.
+        #   "openSUSE Leap",
         # the "%{to_system}" is replaced by the target system name, e.g.
-        # "SUSE Linux Enterprise", the "%{web}" is replaced by a https:// link
+        #   "SUSE Linux Enterprise",
+        # the "%{web}" is replaced by a https:// link
         text = _(<<-HELP
 <h2>Online Migration to %{to_system}</h2>
 <p>
@@ -147,9 +150,10 @@ module MigrationSle
   The migration has several steps:
   <ol>
     <li>Install pending updates (recommended)</li>
-    <li>Register the %{to_system} product</li>
-    <li>Add the SLE repositories</li>
-    <li>Install the SLE packages</li>
+    <li>Register the %{from_system} product</li>
+    <li>Migrate to the %{to_system} product</li>
+    <li>Add the %{to_system} repositories</li>
+    <li>Install the %{to_system} packages</li>
   </ol>
 </p>
 
@@ -167,7 +171,8 @@ module MigrationSle
                 )
         # rubocop:enable Layout/HeredocIndentation, Metrics/MethodLength
 
-        format(text, to_system: TARGET_SYSTEM, web: "https://www.suse.com/support/")
+        format(text, from_system: current_system, to_system: TARGET_SYSTEM,
+          web: "https://www.suse.com/support/")
       end
 
     private

--- a/src/lib/migration_sle/dialogs/registration.rb
+++ b/src/lib/migration_sle/dialogs/registration.rb
@@ -115,15 +115,13 @@ module MigrationSle
         text = _(<<-HELP
 <h2>Online Migration to %{to_system}</h2>
 <p>
-  This YaST module can migrate your system to the %{to_system}
-  (SLE) product. The migration is done online, in the currently
-  running system.
+  This YaST module can migrate your %{from_system} system to %{to_system}.
+  The migration is performed online in the running system.
 </p>
 
 <h3>The Advantages of the Enterprise Product</h3>
 <p>
-  The %{to_system} provides several advantages, the most important
-  ones are:
+  The %{to_system} provides several advantages, the most important ones are:
   <ul>
     <li>Certified system</li>
     <li>Technical support (up to 24/7)</li>
@@ -134,8 +132,8 @@ module MigrationSle
 
 <h3>Obtaining a Subscription</h3>
 <p>
-  There are several ways how to buy a SLE product, it is also possible
-  to buy a subscription online. See <i>%{web}</i> for more details.
+  There are several ways to purchase a SLE subscription. See <i>%{web}</i> for
+  details.
 </p>
 
 <h3>Notes</h3>
@@ -148,21 +146,22 @@ module MigrationSle
 <p>
   The migration has several steps:
   <ol>
-    <li>Registering the openSUSE Leap product</li>
-    <li>Adding the SLE repositories</li>
-    <li>Installing the SLE packages</li>
+    <li>Install pending updates (recommended)</li>
+    <li>Register the %{to_system} product</li>
+    <li>Add the SLE repositories</li>
+    <li>Install the SLE packages</li>
   </ol>
 </p>
 
 <p>
-  After the migration is finished the system should be manually restarted.
+  After completing the migration, restart the system manually.
 </p>
 
 <h3>Input Fields</h3>
 </p>
-  Enter the registration code and E-mail address. If you want to use
-  a local RMT registration server enter its URL instead of
-  the registration code. Leave the E-mail address empty in that case.
+  Enter the registration code and e-mail address. To register with a
+  RMT server, enter its URL instead of the registration code and leave the
+  e-mail address empty.
 </p>
         HELP
                 )


### PR DESCRIPTION
## Problem

I was asked to write a decent help text for the registration dialog. I think the current text is okay, I just reworked it a bit and fixed some errors.

For the background see in https://jira.suse.com/browse/SLE-24216

I really would like to see this in SLE 15 SP5 as default migration method, so I don't have to [document `yast2 migration` and `yast2 migration_sle`](https://susedoc.github.io/doc-sle/main/html/SLES-upgrade/cha-upgrade-online.html#sec-upgrade-online-leap-to-sle). But before this becomes supported, I think the input fields should be aligned with yast registration. (Ab)using the registration code field for the RMT server URL looks like a bad hack.